### PR TITLE
Problem: Version of `requests` library incompatible with Atmosphere requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.4.1
+requests>=2.4.1
 apache-libcloud==0.20.1
 threepio==0.2.0
 rfive==0.2.0


### PR DESCRIPTION
See: https://github.com/cyverse/atmosphere/blob/1c91717c641e1966b71d5ab59034d05b895b734a/requirements.txt

Atmosphere:

```
requests[security]==2.11.1
```

rtwo:

```
requests==2.4.1
```

Python libraries should be more flexible with their requirements than applications.

Solution: Don't lock the exact version of requests down in rtwo. 

