### PR TITLE
unpin python-irodsclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ requests>=2.4.1
 apache-libcloud==0.20.1
 threepio==0.2.0
 rfive==0.2.0
-python-irodsclient==0.4.0
+python-irodsclient
 python-cinderclient==1.9.0
 python-glanceclient==2.5.0
 python-keystoneclient==3.6.0


### PR DESCRIPTION
I'm trying to get some [new functionality](https://github.com/irods/python-irodsclient/pull/67) into python-irodsclient, so we'll need to bump the version that gets installed.

Taking guidance from our [strategy](http://nvie.com/posts/pin-your-packages/) for Python dependency handling, @julianpistorius and I think we should not pin a version here:
> WARNING: Don’t pin by default when you’re building libraries! Only use pinning for end products.