### PR TITLE
Add a new keystone auth method for user driver

### DIFF
--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -82,6 +82,22 @@ def _connect_to_keystone_password(
     password_token = password_sess.get_token()
     return (password_auth, password_sess, password_token)
 
+def _connect_to_keystone_auth_v3(
+        auth_url, auth_token, project_name, domain_name, **kwargs):
+    """
+    Give a auth_url and auth_token,
+    authenticate with keystone version 3 to get a scoped_token,
+    Exchange token to receive an auth, session, token scoped to a sepcific project_name and domain_name.
+    """
+    token_auth = identity.Token(
+        auth_url=auth_url,
+        token=auth_token,
+        project_domain_id=domain_name,
+        project_name=project_name)
+    token_sess = Session(auth=token_auth)
+    token_token = token_sess.get_token()
+    return (token_auth, token_sess, token_token)
+
 def _connect_to_keystone_v2(**kwargs):
     """
     DEPRECATION WARNING: Should only be used by legacy clouds

--- a/rtwo/drivers/openstack_user.py
+++ b/rtwo/drivers/openstack_user.py
@@ -12,8 +12,8 @@ from novaclient.exceptions import NotFound as NovaNotFound
 
 from threepio import logger
 
-from rtwo.drivers.common import _connect_to_keystone_v3, _connect_to_keystone,\
-    _connect_to_nova, _connect_to_swift, _connect_to_nova_by_auth, find
+from rtwo.drivers.common import  _connect_to_keystone_auth_v3, _connect_to_keystone_v3,\
+    _connect_to_keystone, _connect_to_nova, _connect_to_swift, _connect_to_nova_by_auth, find
 
 
 class UserManager():
@@ -49,7 +49,10 @@ class UserManager():
 
     def new_connection(self, *args, **kwargs):
         if kwargs.get('version') == 'v3':
-            (auth, session, token) = _connect_to_keystone_v3(**kwargs)
+            if 'auth_token' in kwargs:
+                (auth, session, token) = _connect_to_keystone_auth_v3(**kwargs)
+            else:
+                (auth, session, token) = _connect_to_keystone_v3(**kwargs)
             keystone = _connect_to_keystone(version="v3", auth=auth, session=session)
             nova = _connect_to_nova_by_auth(auth=auth, session=session)
         else:


### PR DESCRIPTION
@steve-gregory 

Basically pretty much the same idea. Just adding a new method to support token auth of keystone v3 in `openstack_user.py` Free feel to leave your comments.

Thanks!
Lucas 