### PR TITLE
Add sahara and connect glance and swift

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ python-glanceclient==2.5.0
 python-keystoneclient==3.6.0
 python-neutronclient==6.0.0
 python-novaclient==6.0.0
-python-swiftclient==3.1.0
+python-saharaclient==1.2.0
+python-swiftclient==3.3.0
 python-openstackclient==3.3.0
 pbr>=1.8,<2.0

--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -8,6 +8,7 @@ import glanceclient
 import keystoneclient
 from keystoneclient.exceptions import AuthorizationFailure
 from keystoneclient import exceptions
+from saharaclient import client as sahara_client
 from swiftclient import client as swift_client
 from novaclient import client as nova_client
 from novaclient import api_versions
@@ -55,9 +56,23 @@ class LoggedScriptDeployment(ScriptDeployment):
 def _connect_to_swift(*args, **kwargs):
     """
     """
-    swift = swift_client.Connection(*args, **kwargs)
+    if "session" in kwargs:
+        session = kwargs.get("session")
+        swift = swift_client.Connection(session=session)
+    else:
+        swift = swift_client.Connection(*args, **kwargs)
     return swift
 
+def _connect_to_sahara(*args, **kwargs):
+    """
+    Recommand authenticating sahara with session auth
+    """
+    if "session" is kwargs:
+        session = kwargs.get("session")
+        sahara = sahara_client.Client("1.1", session=sess, endpoint_type="internalURL")
+    else:
+        sahara = sahara_client.Client(*args, **kwargs)
+    return sahara
 
 def _connect_to_neutron(*args, **kwargs):
     """

--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -67,11 +67,16 @@ def _connect_to_sahara(*args, **kwargs):
     """
     Recommend authenticating sahara with session auth
     """
-    if "session" is kwargs:
-        session = kwargs.get("session")
-        sahara = sahara_client.Client("1.1", session=session, endpoint_type="internalURL")
-    else:
-        sahara = sahara_client.Client(*args, **kwargs)
+    try:
+        if "session" in kwargs:
+            session = kwargs.get("session")
+            sahara = sahara_client.Client("1.1", session=session, endpoint_type="internalURL")
+        else:
+            sahara = sahara_client.Client(*args, **kwargs)
+    except RuntimeError as client_failure:
+        if "Could not find Sahara endpoint" in client_failure.message:
+            return None
+        raise
     return sahara
 
 def _connect_to_neutron(*args, **kwargs):

--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -65,11 +65,11 @@ def _connect_to_swift(*args, **kwargs):
 
 def _connect_to_sahara(*args, **kwargs):
     """
-    Recommand authenticating sahara with session auth
+    Recommend authenticating sahara with session auth
     """
     if "session" is kwargs:
         session = kwargs.get("session")
-        sahara = sahara_client.Client("1.1", session=sess, endpoint_type="internalURL")
+        sahara = sahara_client.Client("1.1", session=session, endpoint_type="internalURL")
     else:
         sahara = sahara_client.Client(*args, **kwargs)
     return sahara

--- a/rtwo/drivers/openstack_network.py
+++ b/rtwo/drivers/openstack_network.py
@@ -39,9 +39,9 @@ class NetworkManager(object):
         """
         #NOTE: This is a HACK that should be removed when we stop supporting "Legacy Openstack"
         if 'auth_url' in kwargs and '/v2' in kwargs['auth_url']:
-            return _connect_to_neutron(*args, **kwargs)
-
-        if 'session' not in kwargs:
+            neutron = _connect_to_neutron(*args, **kwargs)
+            sahara = None
+        elif 'session' not in kwargs:
             if 'project_name' not in kwargs and 'tenant_name' in kwargs:
                 kwargs['project_name'] = kwargs['tenant_name']
             (auth, session, token) = _connect_to_keystone_v3(**kwargs)

--- a/rtwo/drivers/openstack_network.py
+++ b/rtwo/drivers/openstack_network.py
@@ -15,7 +15,7 @@ import netaddr
 
 from threepio import logger
 
-from rtwo.drivers.common import _connect_to_sahara _connect_to_neutron, _connect_to_keystone_v3
+from rtwo.drivers.common import _connect_to_sahara, _connect_to_neutron, _connect_to_keystone_v3
 from neutronclient.common.exceptions import NeutronClientException, NotFound
 
 ROUTER_INTERFACE_NAMESPACE = (

--- a/rtwo/drivers/openstack_network.py
+++ b/rtwo/drivers/openstack_network.py
@@ -15,7 +15,7 @@ import netaddr
 
 from threepio import logger
 
-from rtwo.drivers.common import _connect_to_neutron, _connect_to_keystone_v3
+from rtwo.drivers.common import _connect_to_sahara _connect_to_neutron, _connect_to_keystone_v3
 from neutronclient.common.exceptions import NeutronClientException, NotFound
 
 ROUTER_INTERFACE_NAMESPACE = (
@@ -31,7 +31,7 @@ class NetworkManager(object):
 
     def __init__(self, *args, **kwargs):
         self.default_router = kwargs.pop("router_name", None)
-        self.neutron = self.new_connection(*args, **kwargs)
+        self.neutron, self.sahara  = self.new_connection(*args, **kwargs)
 
     def new_connection(self, *args, **kwargs):
         """
@@ -46,10 +46,11 @@ class NetworkManager(object):
                 kwargs['project_name'] = kwargs['tenant_name']
             (auth, session, token) = _connect_to_keystone_v3(**kwargs)
             neutron = _connect_to_neutron(session=session)
+            sahara = _connect_to_sahara(session=session)
         else:
             neutron = _connect_to_neutron(*args, **kwargs)
-
-        return neutron
+            sahara = _connect_to_sahara(*args, **kwargs)
+        return neutron, sahara
 
     def tenant_networks(self, tenant_id=None):
         if not tenant_id:

--- a/rtwo/drivers/openstack_user.py
+++ b/rtwo/drivers/openstack_user.py
@@ -12,9 +12,9 @@ from novaclient.exceptions import NotFound as NovaNotFound
 
 from threepio import logger
 
-from rtwo.drivers.common import  _connect_to_keystone_auth_v3, _connect_to_keystone_v3,\
-    _connect_to_keystone, _connect_to_nova, _connect_to_swift, _connect_to_nova_by_auth, find
-
+from rtwo.drivers.common import _connect_to_glance_by_auth, _connect_to_keystone_auth_v3, \
+    _connect_to_keystone_v3, _connect_to_keystone, _connect_to_nova, _connect_to_swift, \
+    _connect_to_nova_by_auth, find
 
 class UserManager():
     keystone = None
@@ -37,7 +37,7 @@ class UserManager():
         return manager
 
     def __init__(self, *args, **kwargs):
-        self.keystone, self.nova, self.swift = self.new_connection(*args, **kwargs)
+        self.keystone, self.nova, self.swift, self.glance = self.new_connection(*args, **kwargs)
         auth_version = kwargs.get('version','v2.0')
         if '2.0' in auth_version:
             self.version = 2
@@ -55,6 +55,8 @@ class UserManager():
                 (auth, session, token) = _connect_to_keystone_v3(**kwargs)
             keystone = _connect_to_keystone(version="v3", auth=auth, session=session)
             nova = _connect_to_nova_by_auth(auth=auth, session=session)
+            glance = _connect_to_glance_by_auth(auth=auth, session=session)
+            swift = _connect_to_swift(session=session)
         else:
             #Legacy cloud method for connection (without keystoneauth1)
             keystone = _connect_to_keystone(*args, **kwargs)
@@ -62,9 +64,10 @@ class UserManager():
             nova_args['version'] = 'v2.0'
             nova_args['auth_url'] = nova_args['auth_url'].replace('v3','v2.0')
             nova = _connect_to_nova(*args, **nova_args)
-        swift_args = self._get_swift_args(*args, **kwargs)
-        swift = _connect_to_swift(*args, **swift_args)
-        return keystone, nova, swift
+            glance = _connect_to_glance_by_auth(*args, **kwargs)
+            swift_args = self._get_swift_args(*args, **kwargs)
+            swift = _connect_to_swift(*args, **swift_args)
+        return keystone, nova, swift, glance
 
     def _get_swift_args(self, *args, **kwargs):
         swift_args = {}

--- a/rtwo/drivers/openstack_user.py
+++ b/rtwo/drivers/openstack_user.py
@@ -12,9 +12,13 @@ from novaclient.exceptions import NotFound as NovaNotFound
 
 from threepio import logger
 
-from rtwo.drivers.common import _connect_to_glance_by_auth, _connect_to_keystone_auth_v3, \
-    _connect_to_keystone_v3, _connect_to_keystone, _connect_to_nova, _connect_to_swift, \
-    _connect_to_nova_by_auth, find
+from rtwo.drivers.common import (
+    _connect_to_nova_by_auth, _connect_to_glance_by_auth,
+    _connect_to_keystone_auth_v3, _connect_to_keystone_v3,
+    _connect_to_glance, _connect_to_keystone,
+    _connect_to_nova, _connect_to_swift,
+    find)
+
 
 class UserManager():
     keystone = None
@@ -54,17 +58,17 @@ class UserManager():
             else:
                 (auth, session, token) = _connect_to_keystone_v3(**kwargs)
             keystone = _connect_to_keystone(version="v3", auth=auth, session=session)
-            nova = _connect_to_nova_by_auth(auth=auth, session=session)
             glance = _connect_to_glance_by_auth(auth=auth, session=session)
+            nova = _connect_to_nova_by_auth(auth=auth, session=session)
             swift = _connect_to_swift(session=session)
         else:
             #Legacy cloud method for connection (without keystoneauth1)
             keystone = _connect_to_keystone(*args, **kwargs)
+            glance = _connect_to_glance(keystone, **kwargs)
             nova_args = kwargs.copy()
             nova_args['version'] = 'v2.0'
             nova_args['auth_url'] = nova_args['auth_url'].replace('v3','v2.0')
             nova = _connect_to_nova(*args, **nova_args)
-            glance = _connect_to_glance_by_auth(*args, **kwargs)
             swift_args = self._get_swift_args(*args, **kwargs)
             swift = _connect_to_swift(*args, **swift_args)
         return keystone, nova, swift, glance

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 10, 'dev', 0)
+VERSION = (0, 5, 11, 'dev', 0)
 
 
 def version_str():

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 11, 'dev', 0)
+VERSION = (0, 5, 10, 'dev', 0)
 
 
 def version_str():


### PR DESCRIPTION
This patch adds a new OpenStack service client: `sahara (data processing`).

Also, connects glance with `_connect_to_glance_by_auth` (written but not used)
Last, it adds a new way of connecting swift: session. 

And in order to do that, we need to use `python-swiftclient==3.3.0` 

Atmosphere PR for upgrading swift client version:  https://github.com/cyverse/atmosphere/pull/389
This solves: https://github.com/cyverse/rtwo/issues/12