### PR TITLE
Add OpenStack heat service to rtwo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ rfive==0.2.0
 python-irodsclient
 python-cinderclient==1.9.0
 python-glanceclient==2.5.0
+python-heatclient==1.11.0
 python-keystoneclient==3.6.0
 python-neutronclient==6.0.0
 python-novaclient==6.0.0

--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -8,6 +8,7 @@ import glanceclient
 import keystoneclient
 from keystoneclient.exceptions import AuthorizationFailure
 from keystoneclient import exceptions
+from heatclient import client as heat_client
 from saharaclient import client as sahara_client
 from swiftclient import client as swift_client
 from novaclient import client as nova_client
@@ -78,6 +79,22 @@ def _connect_to_sahara(*args, **kwargs):
             return None
         raise
     return sahara
+
+def _connect_to_heat(*args, **kwargs):
+    """
+    Recommend authenticating heat with session auth
+    """
+    try:
+        if "session" in kwargs:
+            session = kwargs.get("session")
+            heat = heat_client.Client("1", session=session)
+        else:
+            heat = heat_client.Client(*args, **kwargs)
+    except RuntimeError as client_failure:
+        if "Could not find Heat endpoint" in client_failure.message:
+            return None
+        raise
+    return heat
 
 def _connect_to_neutron(*args, **kwargs):
     """

--- a/rtwo/drivers/openstack_network.py
+++ b/rtwo/drivers/openstack_network.py
@@ -15,7 +15,7 @@ import netaddr
 
 from threepio import logger
 
-from rtwo.drivers.common import _connect_to_sahara, _connect_to_neutron, _connect_to_keystone_v3
+from rtwo.drivers.common import _connect_to_heat, _connect_to_sahara, _connect_to_neutron, _connect_to_keystone_v3
 from neutronclient.common.exceptions import NeutronClientException, NotFound
 
 ROUTER_INTERFACE_NAMESPACE = (
@@ -31,7 +31,7 @@ class NetworkManager(object):
 
     def __init__(self, *args, **kwargs):
         self.default_router = kwargs.pop("router_name", None)
-        self.neutron, self.sahara  = self.new_connection(*args, **kwargs)
+        self.neutron, self.sahara, self.heat  = self.new_connection(*args, **kwargs)
 
     def new_connection(self, *args, **kwargs):
         """
@@ -41,16 +41,19 @@ class NetworkManager(object):
         if 'auth_url' in kwargs and '/v2' in kwargs['auth_url']:
             neutron = _connect_to_neutron(*args, **kwargs)
             sahara = None
+            heat = None
         elif 'session' not in kwargs:
             if 'project_name' not in kwargs and 'tenant_name' in kwargs:
                 kwargs['project_name'] = kwargs['tenant_name']
             (auth, session, token) = _connect_to_keystone_v3(**kwargs)
             neutron = _connect_to_neutron(session=session)
             sahara = _connect_to_sahara(session=session)
+            heat = _connect_to_heat(session=session)
         else:
             neutron = _connect_to_neutron(*args, **kwargs)
             sahara = _connect_to_sahara(*args, **kwargs)
-        return neutron, sahara
+            heat = _connect_to_heat(*args, **kwargs)
+        return neutron, sahara, heat
 
     def tenant_networks(self, tenant_id=None):
         if not tenant_id:


### PR DESCRIPTION
Similar to adding sahara, this patch adds `heat` to rtwo for support orchestration in atmosphere (giji)

@steve-gregory 