### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - "2.7"
 dist: trusty
-script:
-
+script: 
+  - python setup.py install 
 deploy:
   provider: pypi
   user: atmosphere

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.7"
 dist: trusty
+script:
+
 deploy:
   provider: pypi
   user: atmosphere

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: python
+python:
+  - "2.7"
 dist: trusty
 deploy:
   provider: pypi


### PR DESCRIPTION
current CI has some configuration problems. 

@steve-gregory  Not sure how to solve this since I don't know what to put under `scripts` for rtwo.

```
Please override the script: key in your .travis.yml to run tests.
```

https://travis-ci.org/cyverse/rtwo/builds/274368220?utm_source=github_status&utm_medium=notification

Updates on Sept. 12nd:

```error: pbr 1.10.0 is installed but pbr>=2.0.0 is required by set(['python-saharaclient'])```

Not sure why we are requiring `pbr<2.0`, but it turns out we need `pbr=2.0.0` for Sahara now.