### PR TITLE
Problem: Openstack instance APIs no longer perform pagination

### DIFF
--- a/rtwo/drivers/common.py
+++ b/rtwo/drivers/common.py
@@ -164,7 +164,12 @@ def _connect_to_keystone(*args, **kwargs):
     Deprecated: keystoneclient is going away after legacy clouds have been upgraded.
     Use openstackclient instead.
     """
-    logger.warn("Deprecated: keystoneclient is going away after legacy clouds have been upgraded -- convert to openstack-client/sdk")
+
+    try:
+        raise Exception()
+    except:
+        logger.exception("Deprecated: keystoneclient is going away after legacy clouds have been upgraded -- convert to openstack-client/sdk")
+
     version = kwargs.get('version', 'v2.0')
     if version == 'v2.0':
         from keystoneclient.v2_0 import client as ks_client

--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -1284,6 +1284,9 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
                     please provide the floating IP address")
                     return None
                 address = public_ips[0]
+            if not address:
+                logger.warn("No public IP address found for instance %s", server.id)
+                return None
             server_resp = self.connection.request(
                 '/servers/%s/action' % server.id,
                 method='POST',


### PR DESCRIPTION
## Solution:
- Add a HACK to keep track of each instance and verify that it is not a duplicate.
- Add a HACK to use the last instance returned as a 'marker', to ask openstack 'do you have anything else for me?'