### PR TITLE
Problem: Libraries should not pin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,3 @@
-requests>=2.4.1
-apache-libcloud==0.20.1
-threepio==0.2.0
-rfive==0.2.0
-python-irodsclient
-python-cinderclient==1.9.0
-python-glanceclient==2.5.0
-python-heatclient==1.11.0
-python-keystoneclient==3.6.0
-python-neutronclient==6.0.0
-python-novaclient==6.0.0
-python-saharaclient==1.2.0
-python-swiftclient==3.3.0
-python-openstackclient==3.3.0
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/rtwo/__init__.py
+++ b/rtwo/__init__.py
@@ -1,7 +1,0 @@
-""" rtwo
-
-"""
-#FIXME: Remove next 3 lines?
-import libcloud.security
-libcloud.security.VERIFY_SSL_CERT = False
-libcloud.security.VERIFY_SSL_CERT_STRICT = False

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 15, 'dev', 0)
+VERSION = (0, 5, 15, 'dev', 1)
 
 
 def version_str():
@@ -19,61 +19,8 @@ egg_match = "(?P<egg>\S.*[a-zA-Z])"\
             "(?P<opt_version_flag>[-=]+)?"\
             "(?P<opt_version>[0-9]*[0-9.-]*[0-9])?(?P<dev_flag>-dev)?"
             # Version is optional
-def read_requirements(requirements_file):
-    """
-    Requirements files use two specific formats:
-    packagename==1.3.1
-    and
-    git+git://github.com/abc/xyz.git#egg=packagename-1.3.1
 
-    This function converts git to the bottom format
-    and
-    includes them as a dependency_link for setup.py
-    """
-    import re
-    dependencies = []
-    install_requires = []
-    egg_regex = re.compile(egg_match)
-    git_regex = re.compile(git_match)
-    with open(requirements_file, 'r') as f:
-        for line in f.read().split('\n'):
-            # Skip empty spaces
-            if not line:
-                continue
-            # Ignore comments.
-            if line.lstrip().startswith("#"):
-                continue
-            # Read the line for version info
-            r = git_regex.search(line)
-            if not r:
-                r = egg_regex.search(line)
-            if not r:
-                continue
-            group = r.groupdict()
-            if not group:
-                continue
-            #Dependencies will match git_flag
-            if group.get('git_flag'):
-                dependencies.append(line)
-            #Requirements should be added for each line
-            if group.get('opt_version') and group.get('egg'):
-                install_requires.append("%s==%s%s" % (group['egg'], group['opt_version'],
-                        '-dev' if group.get('dev_flag') else ''))
-            elif group.get('egg'):
-                install_requires.append("%s" % (group['egg']))
-    return (dependencies, install_requires)
-
-
-def write_requirements(requirements_file, new_file):
-    (dependencies, install_requires) = read_requirements(requirements_file)
-    with open(new_file,'w') as write_to:
-        write_to.write("#Dependencies:\n")
-        [write_to.write("%s\n" % line) for line in dependencies]
-        write_to.write("#Requirements:\n")
-        [write_to.write("%s\n" % line) for line in install_requires]
-    return
         
-
 def git_sha():
     loc = abspath(dirname(__file__))
     try:

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 15, 'dev', 1)
+VERSION = (0, 6, 0, 'dev', 1)
 
 
 def version_str():

--- a/setup.py
+++ b/setup.py
@@ -88,12 +88,12 @@ class TestCommand(Command):
 setuptools.setup(
     name='rtwo',
     version=get_version('short'),
-    author='iPlant Collaborative',
-    author_email='atmodevs@gmail.com',
+    author='CyVerse',
+    author_email='atmo-dev@cyverse.org',
     description="A unified interface into multiple cloud providers.",
     long_description=long_description,
     license="BSD License, 3 clause",
-    url="https://github.com/iPlantCollaborativeOpenSource/rtwo",
+    url="https://github.com/cyverse/rtwo",
     packages=setuptools.find_packages(),
     dependency_links=[],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,9 @@ from unittest import TextTestRunner, TestLoader
 from glob import glob
 from os.path import splitext, basename, join as pjoin
 import setuptools
-from rtwo.version import get_version, read_requirements
+from rtwo.version import get_version
 
 readme = open('README.md').read()
-dependencies, requirements = read_requirements('requirements.txt')
 
 long_description = """
 rtwo %s
@@ -96,8 +95,21 @@ setuptools.setup(
     license="BSD License, 3 clause",
     url="https://github.com/iPlantCollaborativeOpenSource/rtwo",
     packages=setuptools.find_packages(),
-    dependency_links=dependencies,
-    install_requires=requirements,
+    dependency_links=[],
+    install_requires=[
+        "apache-libcloud",
+        "python-cinderclient",
+        "python-glanceclient",
+        "python-heatclient",
+        "python-irodsclient",
+        "python-neutronclient",
+        "python-novaclient",
+        "python-openstackclient",
+        "python-saharaclient",
+        "python-swiftclient",
+        "rfive",
+        "threepio"
+    ],
     cmdclass={
         'test': TestCommand,
     },


### PR DESCRIPTION
Solution: Specify 'abstract' dependencies without concrete versions.

Also moved the now unpinned dependencies directly into `setup.py`
instead of loading them from the `requirement.txt` file.

During development we still need a `requirements.txt` file. For _DRY_
sake the `requirements.txt` file now installs dependencies by pointing
at the `setup.py` using `-e .`.

In implementing the above I followed the advice in this blog post:
https://caremad.io/posts/2013/07/setup-vs-requirement/

If for some reason we need to limit versions of packages at the
application level then we can use a constraints file:

https://stackoverflow.com/questions/34645821/pip-constraints-files

Alternatively use a tool like `pipenv` or `pip-tools` (as we do for
Atmosphere).