### PR TITLE
Override get_instance with efficient Openstack api variant

### DIFF
--- a/rtwo/driver.py
+++ b/rtwo/driver.py
@@ -436,6 +436,9 @@ class OSDriver(EshDriver, InstanceActionMixin):
             identifier,
             super(EshDriver,self).list_machines, *args, **kwargs)
 
+    def get_instance(self, alias):
+        instance = self._connection.ex_get_node_details(alias)
+        return self.provider.instanceCls(instance, self)
 
     def deploy_init_to(self, *args, **kwargs):
         """


### PR DESCRIPTION
In the drivers that rtwo exposes there are several places where get_instance is
defined. Because libcloud doesn't support `get_instance`, the base classes have
a `get_instance`, which fetches all instances and filters to a select instance.
This doesn't always work. If your driver is scoped to a users identity then
this is usually okay, because --all instances-- isn't that many. If it's the
admin driver and there are 1500+ instances (as of right now) that will result
in response times on the order of 10s of seconds, which isn't good.

This patch overrides the openstack get_instance, with a call directly to
openstack's API