### PR TITLE
Fix fetch all instances timeout and other issues

### DIFF
--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -9,6 +9,7 @@ import os
 import socket
 import sys
 import time
+import urlparse
 from datetime import datetime
 
 from threepio import logger
@@ -926,88 +927,27 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
         """
         List all instances from all tenants of a user
         """
-        #NOTE: THIS IS A HACK -- The 'admin' user should be able to see "All the things" -- HOWEVER
-        # In the current implementation of liberty on jetstream, a call to 'list_all_tenants'
-        # Made by a user with a single tenant will produce *IDENTICAL* results to that same call made by admin.
-        # THIS IS CONSIDERED HARMFUL! So we have blocked all users except the admin accounts from making this call.
-        all_tenants = False
-        if self.key in ['atmoadmin','admin']:
-            all_tenants = True
-        query_params = "?all_tenants=1" if all_tenants else ""
-        server_resp = self.connection.request(
-            '/servers/detail%s' % query_params,
-            method='GET')
-        all_instances = []
-        all_instances_by_id = []
-        next_page = False
-        # Walk through any pagination links
+
+        # Fetch 500 at a time, until all fetched
+        query_params = 'all_tenants=1&limit=500'
+        servers = []
+
         while True:
-            last_response = server_resp.object
-            if type(last_response) != dict or 'servers' not in last_response:
-                raise Exception("The response output for nova has changed (Missing 'servers') -- Ask a developer to update this line of code!")
-            instances = last_response['servers']
-            instance_count = len(instances)
-            all_instances.extend(instances)
-            # HACK -  This 'tracking hack' should also be removed when we can trust the openstack API
-            all_instances_by_id.extend([i['id'] for i in instances if i['id'] not in all_instances_by_id])
-            page_links = last_response.get('servers_links',[])
-            redirect_to = None
-            next_page = False
-            if page_links:
-                for link in page_links:
-                    if next_page:  # we have the right link, skip all others.
-                        continue
-                    if type(link) != dict or 'rel' not in link or 'href' not in link:  # Link is invalid.
-                        raise Exception("The pagination (servers_links) response for nova has changed -- Ask a developer to update this line of code!")
-                    link_type = link.get('rel')
-                    # Ignore any links that don't point to next page
-                    if link_type != 'next':
-                        continue
-                    full_servers_url = link.get('href')
-                    query_params = "?" + full_servers_url.partition('?')[2] # apply query params and make the next request.
-                    server_resp = self.connection.request(
-                        '/servers/detail%s' % query_params,
-                        method='GET')
-                    next_page = True
-            elif instance_count > 500:
-                # THIS IS A DIRTY DIRTY HACK!
-                # This snippet was added to address an immediate problem,
-                # where the underlying issue is that we can no longer
-                # trust the openstack API to properly paginate the
-                # results. We have _a lot_ of results, lets double-check\
-                # that there is _not_ in fact more servers to account for:
-                last_instance_marker = last_response['servers'][-1]['id']
-                query_params = "?all_tenants=1" if all_tenants else ""
-                query_params += "%smarker=%s" % ("&" if all_tenants else "?", last_instance_marker)
-                server_resp = self.connection.request(
-                    '/servers/detail%s' % query_params,
-                    method='GET')
-                new_response = server_resp.object
-                contains_server_id = any(i for i in new_response['servers'] if i['id'] == last_instance_marker)
-                next_page = True if (not contains_server_id) else False
-                if next_page:
-                    logger.warn("WARNING: The api send there were no more results, but %s additional results were found.", len(new_response['servers']))
-# Double-check that 'marker' is not included in the list, and re-call if count is the same as last
-            if not next_page:
+            response = self.connection.request("/servers/detail?" + query_params, method='GET')
+            data = response.object;
+            servers.extend(data['servers'])
+            page_links = data.get('servers_links', [])
+            if not page_links:
                 break
-        # HACK -  This 'tracking hack' should also be removed when we can trust the openstack API
-        if len(all_instances) != len(all_instances_by_id):
-            duplicate_count = abs(len(all_instances) - len(all_instances_by_id))
-            duplicates = []
-            unique_instance_ids = []
-            unique_instances = []
-            for inst in all_instances:
-                if inst['id'] not in unique_instance_ids:
-                    unique_instances.append(inst)
-                    unique_instance_ids.append(inst['id'])
-                else:
-                    if not any(i for i in duplicates if i['id'] == inst['id']):
-                        duplicates.append(inst)
-            all_instances = unique_instances
-            logger.warn("The Openstack API is returning back non-unique pagination. %s Duplicate values have been found: %s" % (duplicate_count, duplicates))
-        # END-HACK -  This 'tracking hack' should also be removed when we can trust the openstack API
-        # Return a completed list of instances from the API, in the original format.
-        return self._to_nodes({'servers': all_instances})
+
+            next_link = next((link for link in page_links if link.get('rel') == "next"), None)
+            if not next_link:
+                break
+
+            parsed = urlparse.urlparse(next_link.get('href'))
+            query_params = parsed.query
+
+        return self._to_nodes({'servers': servers})
 
     @swap_service_catalog(service_type="network", name="neutron")
     def _neutron_delete_quota(self, tenant_id):

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 15, 'dev', 0)
+VERSION = (0, 5, 18, 'dev', 0)
 
 
 def version_str():


### PR DESCRIPTION
## Description
### Problem
  ex_list_all_instances will timeout for certain providers with many instances

### Solution
  paginate the results so we only request 500 at a time

### Details
- Explicitly use pagination to prevent request timeouts. Fetching without a
  page size, would cause IU to take 36 seconds, and Marana and TACC to take 18
  seconds. The timeout would occur at 20 seconds causing the request to fail.
  If we fetch with a page size of 500, it takes no more than 10 seconds.
- Remove hack which ensured uniqueness of results. I verified that the results
  were unique for each provider. I could not replicate the original condition
  motivating that hack.
- Remove hack which only returned all_tenants results for specific tenants. An
  OS provider can choose whether any tenant is allowed to see other tenants
  instances via the `all_tenants` query param. Since this behavior is provider
  specific, we're going to allow the provider to decide and not limit that
  behavior here. I looked around atmosphere's codebase, and the assumption is
  that only the admin ever makes this call anyways. The commit message was
  useless so there is no evidence for why the hack should have been
  introduced.

### Testing
#### Script to print results for each provider, and check uniqueness
```
from core.models import *
from django.db.models import Q
from service.cache import get_cached_driver
from datetime import datetime

providers = Provider.objects.filter(Q(location__contains='iu-jetstream') | Q(location__contains='Marana') | Q(location__contains='TACC') | Q(location__contains='work'))
username = 'cdosborn'

for provider in providers:
    driver = get_cached_driver(provider.admin)
    start = datetime.now()
    instances = driver._connection.ex_list_all_instances()
    delta = datetime.now() - start
    assert len({ i.id for i in instances }) == len(instances), "All instances returned are unique"
    print "{} - {} seconds - {} instances".format(provider.location, delta.seconds, len(instances))
```

#### Script output
```
CyVerse Cloud - Marana - 17 seconds - 667 instances
iu-jetstream - 33 seconds - 1689 instances
workshawp - 1 seconds - 42 instances
TACC - 15 seconds - 1253 instances
```
</details>