### PR TITLE
Fix buggy refactor of ex_list_all_instances

### DIFF
--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -182,7 +182,7 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
                  'name': api_ss.get('displayName',api_ss.get('display_name')),
                  'created': api_ss.get('createdAt',api_ss.get('created_at')),
                  'description': api_ss.get('displayDescription', api_ss.get('display_description')),
-                 'status': api_ss['status']} 
+                 'status': api_ss['status']}
         snapshot = VolumeSnapshot(id=api_ss['id'], driver=self,
                                   size=api_ss['size'], extra=extra)
         return snapshot
@@ -429,7 +429,7 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
         else:
             raise ValueError("To boot a volume, you must select a source."
                     " Available Sources: [image, volume, snapshot]")
-            
+
 
         #NOTE: Wrapped in a list
         server_params["block_device_mapping_v2"] = [block_device_mapping]

--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -928,8 +928,11 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
         List all instances from all tenants of a user
         """
 
-        # Fetch 500 at a time, until all fetched
-        query_params = 'all_tenants=1&limit=500'
+        # Atmosphere depends on the fact that this fetches all instances for a
+        # tenant, but all tenants' instances for admin tenants. Hacky, but
+        # easy enough to fix.
+        all_tenants = self.key in ['atmoadmin','admin']
+        query_params = "limit=500" + ("&all_tenants=1" if all_tenants else "")
         servers = []
 
         while True:


### PR DESCRIPTION
## Description
### Problem
403 permission denied tenant does not have permission to list all tenants (paraphrased)

### Solution
Only show each tenant their instances

In 5f510aabefe0d90879, we introduced pagination but also changed a fundamental behavior. We always fetched all instances for all tenants (`all_tenants=1`). Clouds by default don't allow tenants to view other tenants instances. When a non-admin tenant tried to list all instances (wasn't aware this ever occurred), then the cloud will 403 if the tenant doesnt have permission. This was discovered during the j7m v32 release.