### PR TITLE
Allow external network to be passed to associate_floating_ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.19...HEAD) - YYYY-MM-DD
+## [0.5.20](https://github.com/cyverse/rtwo/compare/0.5.19...0.5.20) - 2018-06-19
 ### Changed
  - Allow external network to be explicitly passed to `associate_floating_ip` ([#27](https://github.com/cyverse/rtwo/pull/27))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.19...HEAD) - YYYY-MM-DD
+### Changed
+ - Allow external network to be explicitly passed to `associate_floating_ip` ([#27](https://github.com/cyverse/rtwo/pull/27))
+
 ## [0.5.19](https://github.com/cyverse/rtwo/compare/0.5.18...0.5.19) - 2018-04-26
 ### Fixed
  - Fix unintentional fetch of all_tenants instances ([#25](https://github.com/cyverse/rtwo/pull/25))

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -72,7 +72,7 @@ def write_requirements(requirements_file, new_file):
         write_to.write("#Requirements:\n")
         [write_to.write("%s\n" % line) for line in install_requires]
     return
-        
+
 
 def git_sha():
     loc = abspath(dirname(__file__))
@@ -94,10 +94,10 @@ def get_version(form='short'):
 
     Takes single argument ``form``, which should be one of the following
     strings:
-    
+
     * ``short`` Returns major + minor branch version string with the format of
     B.b.t.
-    * ``normal`` Returns human readable version string with the format of 
+    * ``normal`` Returns human readable version string with the format of
     B.b.t _type type_num.
     * ``verbose`` Returns a verbose version string with the format of
     B.b.t _type type_num@git_sha
@@ -108,7 +108,7 @@ def get_version(form='short'):
     tertiary = VERSION[2]
     type_ = VERSION[3]
     type_num = VERSION[4]
-    
+
     versions["branch"] = branch
     v = versions["branch"]
     if tertiary:

--- a/rtwo/version.py
+++ b/rtwo/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 19, 'dev', 0)
+VERSION = (0, 5, 20, 'dev', 0)
 
 
 def version_str():


### PR DESCRIPTION
## Description

Problem: When creating a floating IP address and associating it to an instance, rtwo chooses an arbitrary external network (the first one that happens to be returned from the API). If there are multiple extrenal networks, rtwo may select a network which is unreachable from the user's private network (no router connects them).

Solution: When using external router topology, support explicitly specifying an external network when creating a floating IP address. (Atmosphere(2) will determine the correct external network based on the user's assigned public router.)

Co-depends on [Atmosphere(2) #624](https://github.com/cyverse/atmosphere/pull/624).

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.