### PR TITLE
Change the mock driver to closely imitate standard libcloud driver

### DIFF
--- a/rtwo/__init__.py
+++ b/rtwo/__init__.py
@@ -1,7 +1,6 @@
-""" rtwo
-
-"""
-#FIXME: Remove next 3 lines?
-import libcloud.security
-libcloud.security.VERIFY_SSL_CERT = False
-libcloud.security.VERIFY_SSL_CERT_STRICT = False
+try:
+    import libcloud.security
+    libcloud.security.VERIFY_SSL_CERT = False
+    libcloud.security.VERIFY_SSL_CERT_STRICT = False
+except ImportError:
+    pass

--- a/rtwo/driver.py
+++ b/rtwo/driver.py
@@ -348,9 +348,40 @@ class MockDriver(EshDriver, InstanceActionMixin):
     def is_valid(self):
         return True
 
-    def __init__(self, provider, identity, **provider_credentials):
-        super(MockDriver, self).__init__(provider, identity, **provider_credentials)
-        #Set connection && force_service_region
+    def list_locations(self, *args, **kwargs):
+        return []
+
+    def create_instance(self, *args, **kwargs):
+        """
+        Return the InstanceClass representation of a libcloud node
+        """
+        default_extra = {
+            "metadata": {},
+            "status": "active",
+            "task": "",
+            "availability_zone": "nova",
+            "created": datetime.strftime(datetime.now(),
+                                         "%Y-%m-%dT%H:%M:%SZ")
+        }
+        default_extra.update(kwargs.get("extra", {}))
+        kwargs["extra"] = default_extra
+        return super(MockDriver, self).create_instance(*args, **kwargs)
+
+    def _clean_floating_ip(self, *args, **kwargs):
+        return self._connection.ex_clean_floating_ip(**kwargs)
+
+    def suspend_instance(self, instance):
+        return self._connection.suspend_node(instance._node)
+
+    def resume_instance(self, instance):
+        return self._connection.resume_node(instance._node)
+
+    def start_instance(self, instance):
+        return self._connection.start_node(instance._node)
+
+    def stop_instance(self, instance):
+        return self._connection.stop_node(instance._node)
+
 
 class OSDriver(EshDriver, InstanceActionMixin):
     """

--- a/rtwo/drivers/mock.py
+++ b/rtwo/drivers/mock.py
@@ -1,0 +1,131 @@
+import uuid
+from libcloud.common.base import ConnectionKey
+from libcloud.compute.base import Node
+from libcloud.compute.base import NodeDriver
+from libcloud.compute.base import KeyPair
+from libcloud.compute.types import Provider, NodeState
+
+
+class MockConnection(ConnectionKey):
+    def connect(self, host=None, port=None):
+        pass
+
+
+class MockNodeDriver(NodeDriver):
+
+    name = "Mock Node Provider"
+    website = 'http://example.com'
+    type = Provider.DUMMY
+    all_nodes = []
+    all_volumes = []
+    all_instances = []
+    all_images = []
+    all_sizes = []
+
+    def __init__(self, creds):
+        self.creds = creds
+        self.connection = MockConnection(self.creds)
+
+    def get_uuid(self, unique_field=None):
+        return str(uuid.uuid4())
+
+    def list_nodes(self):
+        return self.all_nodes
+
+    def start_node(self, node):
+        node.state = NodeState.RUNNING
+
+    def stop_node(self, node):
+        node.state = NodeState.STOPPED
+
+    def reboot_node(self, node, reboot_type='SOFT'):
+        node.state = NodeState.REBOOTING
+
+    def resume_node(self, node):
+        node.state = NodeState.RUNNING
+
+    def suspend_node(self, node):
+        node.state = NodeState.SUSPENDED
+
+    def destroy_node(self, node, *args, **kwargs):
+        node.state = NodeState.TERMINATED
+        index = self.all_nodes.index(node)
+        return self.all_nodes.pop(index)
+
+    def import_key_pair_from_string(self, name, key_material):
+        key_pair = KeyPair(
+            name=name,
+            public_key=key_material,
+            fingerprint='fingerprint',
+            private_key='private_key',
+            driver=self)
+        return key_pair
+
+    def is_valid(self):
+        return True
+
+    def _get_size(self, alias):
+        size = MockSize("Unknown", self.providerCls())
+        return size
+
+    def list_all_volumes(self, *args, **kwargs):
+        """
+        Return the InstanceClass representation of a libcloud node
+        """
+        return self.all_volumes
+
+    def get_instance(self, instance_id, *args, **kwargs):
+        """
+        Return the InstanceClass representation of a libcloud node
+        """
+        instances = self.list_all_instances()
+        instance = [inst for inst in instances if inst.id == instance_id]
+        if not instance:
+            return None
+        return instance[0]
+
+    def list_images(self, *args, **kwargs):
+        """
+        Return the MachineClass representation of a libcloud NodeImage
+        """
+        return self.all_images
+
+    def list_sizes(self, *args, **kwargs):
+        """
+        Return the SizeClass representation of a libcloud NodeSize
+        """
+        return self.all_sizes
+
+    def create_node(self,
+                    id=None,
+                    name=None,
+                    source=None,
+                    ip=None,
+                    size=None,
+                    extra={},
+                    *args,
+                    **kwargs):
+        id = id or uuid.uuid4()
+        name = name or 'dummy-{}'.format(id),
+        node = Node(
+            id=id,
+            name=name,
+            state=NodeState.RUNNING,
+            public_ips=[ip],
+            private_ips=[],
+            driver=self,
+            size=size,
+            extra=extra,
+            *args,
+            **kwargs)
+        self.all_nodes.append(node)
+        return node
+
+    def ex_list_all_instances(self):
+        return self.all_nodes
+
+    def ex_add_fixed_ip(self, instance, network_id):
+        pass
+
+    def ex_clean_floating_ip(*args, **kwargs):
+        pass

--- a/rtwo/models/machine.py
+++ b/rtwo/models/machine.py
@@ -3,6 +3,7 @@ Atmosphere service machine.
 
 """
 from abc import ABCMeta
+import uuid
 
 from rtwo.models.provider import AWSProvider, EucaProvider, OSProvider
 
@@ -15,6 +16,8 @@ class BaseMachine(object):
 class MockMachine(BaseMachine):
 
     def __init__(self, image_id, provider):
+        if not image_id:
+            image_id = uuid.uuid4()
         self.id = image_id
         self.alias = image_id
         self.name = 'Unknown image %s' % image_id

--- a/rtwo/models/provider.py
+++ b/rtwo/models/provider.py
@@ -9,6 +9,7 @@ from libcloud.compute.types import Provider as LProvider
 from threepio import logger
 
 from rtwo.drivers.openstack_facade import OpenStack_Esh_NodeDriver
+from rtwo.drivers.mock import MockNodeDriver
 from rtwo.drivers.eucalyptus import Eucalyptus_Esh_NodeDriver
 from rtwo.drivers.aws import Esh_EC2NodeDriver
 
@@ -233,6 +234,20 @@ class EucaProvider(Provider):
 class MockProvider(Provider):
     name = 'Mock'
     location = 'MOCK'
+
+    @classmethod
+    def set_meta(cls):
+        from rtwo.models.identity import MockIdentity
+        from rtwo.models.machine import MockMachine
+        from rtwo.models.instance import MockInstance
+        from rtwo.models.size import MockSize
+        from rtwo.models.volume import MockVolume
+        cls.identityCls = MockIdentity
+        cls.machineCls = MockMachine
+        cls.instanceCls = MockInstance
+        cls.sizeCls = MockSize
+        cls.volumeCls = MockVolume
+
     def set_options(self, provider_credentials):
         """
         Get provider specific options.
@@ -255,7 +270,9 @@ class MockProvider(Provider):
         Return the libcloud.compute driver class.
         """
         self.set_options(provider_credentials)
-        return None
+        self.lc_driver = MockNodeDriver
+        return self.lc_driver(provider_credentials)
+
 
 class OSProvider(Provider):
 

--- a/rtwo/models/size.py
+++ b/rtwo/models/size.py
@@ -3,6 +3,7 @@ Atmosphere service size.
 
 """
 from abc import ABCMeta
+import uuid
 
 from rtwo.models.provider import AWSProvider, EucaProvider, OSProvider
 from threepio import logger
@@ -110,6 +111,8 @@ class Size(BaseSize):
 
 class MockSize(Size):
     def __init__(self, size_id, provider):
+        if not size_id:
+            size_id = uuid.uuid4()
         self.provider = provider
         self._size = None
         self.name = "Unknown Size %s" % size_id


### PR DESCRIPTION
## Description
Change the mock driver to closely imitate libcloud driver

MockInstance is backed by an actual libcloud Node, and there is now a NodeDriver. Atmosphere sometimes reached into the connection object on a driver, and the prior mock driver did not have a connection object.

```
In [1]: from api.tests.factories import IdentityFactory
   ...: from service.driver import get_esh_driver
   ...: from core.models import *
   ...: user = AtmosphereUser.objects.get(username='cdosborn')
   ...: mock_ident = IdentityFactory.create(provider__type__name='mock', created_by=user)
   ...: mock_driver = get_esh_driver(mock_ident)
   ...: instance = mock_driver.create_instance()

In [2]: instance.get_status()
Out[2]: 'active'

In [3]: mock_driver.stop_instance(instance)

In [4]: instance.get_status()
Out[4]: 'shutoff'
```

## Checklist before merging Pull Requests
- [ ] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.