### PR TITLE
Fix pagination logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.22...HEAD) - YYYY-MM-DD
+### Changed
+ - Change ex_list_all_instances to fetch next page until no remaining results
+   ([#32](https://github.com/cyverse/rtwo/pull/32))
+
 ## [0.5.22](https://github.com/cyverse/rtwo/compare/0.5.21...0.5.22) - 2018-08-02
 ### Changed
  - Change ex_list_all_instances performs manual pagination, doesn't rely on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,23 +26,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.22...HEAD) - YYYY-MM-DD
 ### Changed
- - Change ex_list_all_instances to fetch next page until no remaining results
-   ([#32](https://github.com/cyverse/rtwo/pull/32))
+  - Change ex_list_all_instances to fetch next page until no remaining results
+    ([#32](https://github.com/cyverse/rtwo/pull/32))
 
 ## [0.5.22](https://github.com/cyverse/rtwo/compare/0.5.21...0.5.22) - 2018-08-02
 ### Changed
- - Change ex_list_all_instances performs manual pagination, doesn't rely on
-   optional servers_links ([#31](https://github.com/cyverse/rtwo/pull/31))
+  - Change ex_list_all_instances performs manual pagination, doesn't rely on
+    optional servers_links ([#31](https://github.com/cyverse/rtwo/pull/31))
 
 ## [0.5.21](https://github.com/cyverse/rtwo/compare/0.5.20...0.5.21) - 2018-06-29
 ### Fixed
- - The incorrect version (0.5.19) of rtwo was was uploaded to pypi as 0.5.20. The
-   changes originally intended for 0.5.20 were re-uploaded as 0.5.21
+  - The incorrect version (0.5.19) of rtwo was was uploaded to pypi as 0.5.20.
+    The changes originally intended for 0.5.20 were re-uploaded as 0.5.21
 
 ## [0.5.20](https://github.com/cyverse/rtwo/compare/0.5.19...0.5.20) - 2018-06-19
 ### Changed
- - Allow external network to be explicitly passed to `associate_floating_ip` ([#27](https://github.com/cyverse/rtwo/pull/27))
+  - Allow external network to be explicitly passed to `associate_floating_ip`
+    ([#27](https://github.com/cyverse/rtwo/pull/27))
 
 ## [0.5.19](https://github.com/cyverse/rtwo/compare/0.5.18...0.5.19) - 2018-04-26
 ### Fixed
- - Fix unintentional fetch of all_tenants instances ([#25](https://github.com/cyverse/rtwo/pull/25))
+  - Fix unintentional fetch of all_tenants instances
+    ([#25](https://github.com/cyverse/rtwo/pull/25))

--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -944,7 +944,11 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
             response = self.connection.request("/servers/detail?" + query_params)
             data = response.object;
             servers.extend(data['servers'])
-            if len(data['servers']) < limit:
+
+            # It would be smarter to just check if len < limit. In practice
+            # the compute apis sometimes return less than page limit even when
+            # more pages exist
+            if not len(data['servers']):
                 break
 
             last_server = data['servers'][-1]


### PR DESCRIPTION
## Description

### Problem
Instances were being enddated because atmosphere was only receiving a subset of all instances

### Solution
Fix pagination

Previously, we would keep fetching the next page, while the # returned were 500. We inferred that if the # returned were less than the page size, then it had fetched the last page. (We tested this and it seemed to be reliable). However, the api sometimes returns 499 even when there are more pages to fetch. The code has been corrected to fetch until no results are returned, which will inevitably incur 1 unnecessary api call each time.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.