### PR TITLE
Handle errors in pagination gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.23...HEAD) - YYYY-MM-DD
+### Added
+  - Added graceful handling of pagination errors
+    ([#35](https://github.com/cyverse/rtwo/pull/35))
+
 ## [0.5.23](https://github.com/cyverse/rtwo/compare/0.5.22...0.5.23) - 2018-08-31
 ### Changed
   - Change ex_list_all_instances to fetch next page until no remaining results

--- a/rtwo/drivers/openstack_facade.py
+++ b/rtwo/drivers/openstack_facade.py
@@ -935,14 +935,16 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
         # Atmosphere depends on the fact that this fetches all instances for a
         # tenant, but all tenants' instances for admin tenants. Hacky, but
         # easy enough to fix.
-        all_tenants = self.key in ['atmoadmin','admin']
+        all_tenants = self.key in ['atmoadmin', 'admin']
         limit = 500
         query_params = build_query_params(all_tenants, limit)
         servers = []
 
         while True:
-            response = self.connection.request("/servers/detail?" + query_params)
-            data = response.object;
+            response = self.connection.request(
+                "/servers/detail?" + query_params
+            )
+            data = response.object
             servers.extend(data['servers'])
 
             # It would be smarter to just check if len < limit. In practice
@@ -952,7 +954,9 @@ class OpenStack_Esh_NodeDriver(OpenStack_1_1_NodeDriver):
                 break
 
             last_server = data['servers'][-1]
-            query_params = build_query_params(all_tenants, limit, marker=last_server["id"])
+            query_params = build_query_params(
+                all_tenants, limit, marker=last_server["id"]
+            )
 
         return self._to_nodes({'servers': servers})
 


### PR DESCRIPTION
## Description
In the case where the api returns duplicates, we log an error and fallback to fetching without pagination.

This handles several problems that arised. In one case a nova service was really confused about pagination and kept returning the same results in a different order. We would loop forever, causing the owner process to hang indefinitely. This occurred reliably with the `xoberns` user on the `IU` provider.

Another problem (albeit hypothetical) was that we didn't do any checking of duplicates, so we were possibly returning a non unique list.

In my testing I verified that error was reported in the log when duplicates were present. I tested that the connection timeout was restored after it had been patched.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.