### PR TITLE
Problem: Not handling instance started from deleted volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/rtwo/compare/0.5.24...HEAD) - YYYY-MM-DD
+### Fixed
+  - Handle Libcloud exceptions when loading instances with missing source volume 
+    ([#40](https://github.com/cyverse/rtwo/pull/40))
 ## [0.5.24](https://github.com/cyverse/rtwo/compare/0.5.23...0.5.24) - 2018-09-24
 ### Added
   - Added graceful handling of pagination errors

--- a/rtwo/models/instance.py
+++ b/rtwo/models/instance.py
@@ -2,6 +2,7 @@
 Atmosphere service instance.
 
 """
+from libcloud.common.exceptions import BaseHTTPError
 from threepio import logger
 
 from rtwo.models.provider import AWSProvider, EucaProvider, OSProvider
@@ -174,7 +175,10 @@ class OSInstance(Instance):
             attachments = node.extra.get('volumes_attached')
         if not attachments:
             return None
-        volume = self._test_node_is_booted_volume(driver, node, attachments)
+        try:
+            volume = self._test_node_is_booted_volume(driver, node, attachments)
+        except BaseHTTPError:
+            return None
         if not volume:
             return None
         source = OSVolume(volume)


### PR DESCRIPTION
When we look for the volume that a server was started from, and the
volume no longer exists, Libcloud throws an exception.

This then results in #39: Instances started from missing volume halts
`monitor_instances_for` task

Solution: Catch exception when getting source volume, returning `None`
for the source, instead of bubbling the exception up further.

Note: Atmosphere will fail if an instance has a source of `None`, but in
this case it shouldn't matter. This scenario can only happen when a
server was started outside of Atmosphere (via API) and so should be
filtered out of instances that Atmosphere cares about before it tries to
create an Atmosphere InstanceSource object.

Fixes #39 

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
