### PR TITLE
Move source volume check to be last

### DIFF
--- a/rtwo/models/instance.py
+++ b/rtwo/models/instance.py
@@ -24,13 +24,13 @@ class Instance(object):
         Retrieve correct source based on instance details
         NOTE: Occasionally more data may be required/things may slow down here.
         """
-        source = self._get_source_volume(node, driver)
-        if source:
-            return source
         source = self._get_source_snapshot(node)
         if source:
             return source
         source = self._get_source_image(node)
+        if source:
+            return source
+        source = self._get_source_volume(node, driver)
         return source
 
     def _get_source_snapshot(self, node):
@@ -184,7 +184,7 @@ class OSInstance(Instance):
     def _test_node_is_booted_volume(self, driver, node, attachments=[]):
         """
         Given a node and a volume_id, return 'volume' if the node
-        is 'running' the volume, otherwise return None 
+        is 'running' the volume, otherwise return None
         """
         instance_id = node.id
         if not attachments:


### PR DESCRIPTION
## Description

Jetstream encountered an error because Openstack showed a volume was attached to an instance even though it was detached and deleted. When trying to shelve a different instance, rtwo checked sources for all the users' instances. Once it noticed the instance supposedly had an attachment, it tried to check if it was bootable and encountered an error since the volume was deleted.

This fix makes rtwo check for bootable volumes after checking snapshots and images. Since Atmosphere does not support bootable volumes, this function should not be reached, but I wanted to leave it in so I would not be removing features from rtwo.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] Reviewed and approved by at least one other contributor.
