### PR TITLE
Take out google name servers default

### DIFF
--- a/rtwo/drivers/openstack_network.py
+++ b/rtwo/drivers/openstack_network.py
@@ -460,10 +460,9 @@ class NetworkManager(object):
         if subnet_pool_id:
             subnet['subnetpool_id'] = subnet_pool_id
         else:
-            if not dns_nameservers:
-                dns_nameservers = ['8.8.8.8', '8.8.4.4']
-            subnet['dns_nameservers'] = dns_nameservers
-            subnet['cidr'] = cidr
+            if dns_nameservers:
+                subnet['dns_nameservers'] = dns_nameservers
+                subnet['cidr'] = cidr
         logger.debug("Creating subnet - %s" % subnet)
         subnet_obj = neutron.create_subnet({'subnet': subnet})
         return subnet_obj['subnet']


### PR DESCRIPTION
JS experienced extreme slowness when 8.8.8.8 was blocked, removing this as default to avoid that condition in the future.

<!--
## Description

Please describe your pull request. If you're solving a problem, include a oneline problem and oneline solution statement. Otherwise, just begin with a single line summary.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.
-->
